### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Objective-C UIView subclass that flips like a double-sided coin between two view
 ![ScreenShot](https://raw.github.com/ClaudeSutterlin/CMSCoinView/master/CMSCoinView.gif)
 
 
-##Usage
+## Usage
 Create an IBOutlet with the class of CMSCoinView in your header
 
 `@property (nonatomic, retain) IBOutlet CMSCoinView *coinView;`
@@ -18,6 +18,6 @@ Then create your two views and set them on the coin view.
  `[coinView setSecondaryView: profileView];`
 
 
-##Optionally
+## Optionally
 
  `[coinView setSpinTime:1.0];`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
